### PR TITLE
Upgrade dependency version to resolve at least one warning

### DIFF
--- a/MMM-GoogleMaps-Tracking.js
+++ b/MMM-GoogleMaps-Tracking.js
@@ -24,7 +24,7 @@ Module.register("MMM-GoogleMaps-Tracking",{
     start: function () {
 		self = this;
 		self.loaded = false;
-		var scriptSrc = "https://maps.googleapis.com/maps/api/js?key=" + self.config.apikey;
+		var scriptSrc = "https://maps.googleapis.com/maps/api/js?key=" + self.config.apikey + '&loading=async';
         Log.info("Starting module: " + this.name);
 		
         function hasMapsScript(src){

--- a/MMM-GoogleMaps-Tracking.js
+++ b/MMM-GoogleMaps-Tracking.js
@@ -167,7 +167,7 @@ Module.register("MMM-GoogleMaps-Tracking",{
                 latitude = parseFloat(self.config.marker[i].lat);
                 longitude = parseFloat(self.config.marker[i].lon);
 
-				marker = new MarkerWithLabel({
+				marker = new markerWithLabel.MarkerWithLabel({
                     position:{
                         lat:latitude,
                         lng:longitude

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "MMM-GoogleMaps-Tracking",
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "MMM-GoogleMaps-Tracking",
   "version": "2.1.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -9,20 +9,14 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@googlemaps/markerwithlabel": "latest"
+        "@googlemaps/markerwithlabel": "^2.0.28"
       }
     },
     "node_modules/@googlemaps/markerwithlabel": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@googlemaps/markerwithlabel/-/markerwithlabel-1.0.3.tgz",
-      "integrity": "sha512-K1CATqFMj5tIdJWj99hGG8/AhD5YoIKMGJF+o8pJSOw84rLOm6dopkdoN62BarFiRzXVac71VvHW6nP0+1TYcA=="
-    }
-  },
-  "dependencies": {
-    "@googlemaps/markerwithlabel": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@googlemaps/markerwithlabel/-/markerwithlabel-1.0.3.tgz",
-      "integrity": "sha512-K1CATqFMj5tIdJWj99hGG8/AhD5YoIKMGJF+o8pJSOw84rLOm6dopkdoN62BarFiRzXVac71VvHW6nP0+1TYcA=="
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerwithlabel/-/markerwithlabel-2.0.28.tgz",
+      "integrity": "sha512-4u0UVqeELgHDvR+3ibInIhJHFJYg1jH0R4SXq2TXRu95HHdzQwJoBbC7eo/k+cRGWBwabzHo48sa87g9k8mvMw==",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "git+https://github.com/MartinGris/MMM-GoogleMaps-Tracking#readme",
   "dependencies": {
-    "@googlemaps/markerwithlabel": "latest"
+    "@googlemaps/markerwithlabel": "^2.0.28"
   }
 }


### PR DESCRIPTION
See #21 
Changed package.json from asking for `latest` version of dependency (which wasn't working) to 2.0.28 (latest).
Updated the main js file to correct for the new way of calling the dependency.